### PR TITLE
Clarification conf module

### DIFF
--- a/config/conf_gn_module.toml.example
+++ b/config/conf_gn_module.toml.example
@@ -1,0 +1,8 @@
+# Fichier listant les paramètres du module et leurs valeurs par défaut
+
+# Paramètres créés automatiquement au moment de l'installation du module
+
+api_url = '/suivi_chiro'
+id_application = 101
+
+# Paramètres du module

--- a/config/conf_gn_module.toml.sample
+++ b/config/conf_gn_module.toml.sample
@@ -1,3 +1,0 @@
-#Parametres de configuration du module Validation
-
-id_application = 101

--- a/config/conf_schema_toml.py
+++ b/config/conf_schema_toml.py
@@ -1,5 +1,7 @@
 '''
    Spécification du schéma toml des paramètres de configurations
+   Fichier spécifiant les types des paramètres et leurs valeurs par défaut
+   Fichier à ne pas modifier. Paramètres surcouchables dans config/config_gn_module.tml
 '''
 
 from marshmallow import Schema, fields


### PR DESCRIPTION
On n'a plus de sample de conf_gn_module.toml mais un exemple qui liste les paramètres du module surcouchables et leurs valeurs par défaut